### PR TITLE
Feature - Post Read Time

### DIFF
--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -39,6 +39,7 @@ public class PostController : ControllerBase
                 Title = p.Title,
                 DateCreated = p.DateCreated,
                 PublicationDate = p.PublicationDate,
+                EstimatedReadTime = p.EstimatedReadTime,
                 UserProfile = new UserProfileForPostDTO()
                 {
                     Id = p.UserProfile.Id,
@@ -98,6 +99,7 @@ public class PostController : ControllerBase
             HeaderImageURL = foundPost.HeaderImageURL,
             DateCreated = foundPost.DateCreated,
             PublicationDate = foundPost.PublicationDate,
+            EstimatedReadTime = foundPost.EstimatedReadTime,
             UserProfile = new UserProfileForPostDTO()
             {
                 Id = foundPost.UserProfile.Id,
@@ -257,6 +259,7 @@ public class PostController : ControllerBase
             HeaderImageURL = p.HeaderImageURL,
             DateCreated = p.DateCreated,
             PublicationDate = p.PublicationDate,
+            EstimatedReadTime = p.EstimatedReadTime,
             UserProfile = new UserProfileForPostDTO()
             {
                 Id = p.UserProfile.Id,

--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -248,7 +248,7 @@ public class PostController : ControllerBase
             .Include(p => p.Category)
             .ToList();
 
-        List<PostsForUnapprovedDTO> postDTOs = postList.Select(p => new PostsForUnapprovedDTO
+        List<PostForUnapprovedDTO> postDTOs = postList.Select(p => new PostForUnapprovedDTO
         {
             Id = p.Id,
             UserProfileId = p.UserProfileId,

--- a/Models/DTOs/Post/PostForDetailsDTO.cs
+++ b/Models/DTOs/Post/PostForDetailsDTO.cs
@@ -26,6 +26,8 @@ public class PostForDetailsDTO
 
     public DateTime? PublicationDate { get; set; }
 
+    public int EstimatedReadTime { get; set; }
+
     public UserProfileForPostDTO UserProfile { get; set; }
     public CategoryNoNavDTO Category { get; set; }
     public List<TagNoNavDTO> Tags { get; set; }

--- a/Models/DTOs/Post/PostForListDTO.cs
+++ b/Models/DTOs/Post/PostForListDTO.cs
@@ -24,6 +24,8 @@ public class PostForListDTO
 
     public DateTime? PublicationDate { get; set; }
 
+    public int EstimatedReadTime { get; set; }
+
     public UserProfileForPostDTO UserProfile { get; set; }
     public CategoryNoNavDTO Category { get; set; }
     public List<TagNoNavDTO> Tags { get; set; }

--- a/Models/DTOs/Post/PostForUnapprovedDTO.cs
+++ b/Models/DTOs/Post/PostForUnapprovedDTO.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Tabloid.Models.DTOs;
+
+public class PostForUnapprovedDTO
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int UserProfileId { get; set; }
+
+    public int? CategoryId { get; set; }
+
+    [Required]
+    public bool IsApproved { get; set; }
+
+    [Required]
+    public string Title { get; set; }
+
+    [Required]
+    public string Content { get; set; }
+
+    public string HeaderImageURL { get; set; }
+
+    public DateTime DateCreated { get; set; }
+
+    public DateTime? PublicationDate { get; set; }
+
+    public int EstimatedReadTime { get; set; }
+
+    public UserProfileForPostDTO UserProfile { get; set; }
+    public CategoryNoNavDTO Category { get; set; }
+    public string FormattedPublicationDate
+    {
+        get
+        {
+            if (PublicationDate == null)
+            {
+                return DateCreated.ToString("MMMM dd, yyyy");
+            }
+
+            return PublicationDate.Value.ToString("MMMM dd, yyyy");
+        }
+    }
+}

--- a/Models/DTOs/Post/PostsForUnapproved.cs
+++ b/Models/DTOs/Post/PostsForUnapproved.cs
@@ -26,6 +26,8 @@ public class PostsForUnapprovedDTO
 
     public DateTime? PublicationDate { get; set; }
 
+    public int EstimatedReadTime { get; set; }
+
     public UserProfileForPostDTO UserProfile { get; set; }
     public CategoryNoNavDTO Category { get; set; }
     public string FormattedPublicationDate

--- a/Models/Post.cs
+++ b/Models/Post.cs
@@ -24,6 +24,22 @@ public class Post
     public DateTime DateCreated { get; set; }
     public DateTime? PublicationDate { get; set; }
 
+    public int EstimatedReadTime
+    {
+        get
+        {
+            int wordCount = Content == null ? 0 : Content.Split().Count();
+            if (wordCount == 0)
+            {
+                return 0;
+            }
+
+            int timeToRead = (int)Math.Ceiling((decimal) wordCount / 265);
+            
+            return timeToRead;
+        }
+    }
+
     public UserProfile UserProfile { get; set; }
     public Category Category { get; set; }
     public List<PostTag> PostTags { get; set; }

--- a/client/src/components/posts/ApprovePost.jsx
+++ b/client/src/components/posts/ApprovePost.jsx
@@ -62,8 +62,11 @@ export default function ApprovePost({loggedInUser}){
                                     </div>
                                 </>
                             )}
-                            <CardSubtitle className="fw-bold">{up.userProfile.fullName}</CardSubtitle>
+                            <div className="fw-bold">{up.userProfile.fullName}</div>
                             <CardSubtitle>{up.formattedPublicationDate}</CardSubtitle>
+                            <CardSubtitle className="fst-italic">
+                                {up.estimatedReadTime} {up.estimatedReadTime > 1 ? "minutes" : "minute"}
+                            </CardSubtitle>
                             <CardText className="mt-3">{up.content}</CardText>
                             <div className="d-flex flex-row flex-wrap mt-3 w-100 gap-2">
                                 {(loggedInUser.id == up.userProfileId || loggedInUser.roles.includes("Admin")) && (

--- a/client/src/components/posts/PostDetails.jsx
+++ b/client/src/components/posts/PostDetails.jsx
@@ -133,8 +133,11 @@ export const PostDetails = ({ loggedInUser }) => {
                             })}
                         </div>
                     )}
-                    <CardSubtitle className="fw-bold mt-3">{post.userProfile.fullName}</CardSubtitle>
+                    <div className="fw-bold mt-2">{post.userProfile.fullName}</div>
                     <CardSubtitle>{post.formattedPublicationDate}</CardSubtitle>
+                    <CardSubtitle className="fst-italic">
+                        {post.estimatedReadTime} {post.estimatedReadTime > 1 ? "minutes" : "minute"}
+                    </CardSubtitle>
                     <CardText className="mt-3">{post.content}</CardText>
                     <div className="d-flex flex-column align-items-end">
                         <div className="d-flex flex-row flex-wrap gap-1">

--- a/client/src/components/posts/PostList.jsx
+++ b/client/src/components/posts/PostList.jsx
@@ -109,6 +109,9 @@ export const PostList = ({ loggedInUser }) => {
                                     {p.userProfile.fullName}
                                 </CardText>
                             )}
+                            <div className="flex-fill text-end">
+                                {p.estimatedReadTime} {p.estimatedReadTime > 1 ? "minutes" : "minute"}
+                            </div>
                         </div>
                         <div>
                             {p.tags.length > 0 && (


### PR DESCRIPTION
### Purpose
To allow Users to know about how long it will take to read a Post before reading it

### Files Changed
- Changed filename and classname to PostForUnapprovedDTO in `PostForUnapprovedDTO.cs`
- Added calculated property EstimatedReadTime to `Post.cs`
- Added EstimatedReadTime property to `PostForDetailsDTO.cs`, `PostForListDTO.cs`, and `PostForUnapprovedDTO.cs`
- Updated endpoints getting Posts to include EstimatedReadTime, and updated GetUnapproved endpoint to use updated DTO class name in `PostController.cs`
- Updated rendering to include the estimated read time for a Post in `ApprovePost.jsx`, `PostDetails.jsx`, and `PostList.jsx`

### To Test
Fetch, setup, and run according to project README, then confirm the following
- Posts include an estimated read time in Posts List view, Post Details view, and Unapproved Posts view
- Estimated read time for each Post is the word count of the content divided by 265 and rounded up to the nearest integer

closes #1