### PR TITLE
Feature - Unapprove Post

### DIFF
--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -401,8 +401,23 @@ public class PostController : ControllerBase
 
         postToApprove.IsApproved = true;
         _dbContext.SaveChanges();
+        
         return NoContent();
+    }
 
+    [HttpPut("{id}/unapprove")]
+    public IActionResult Unapprove(int id)
+    {
+        Post postToUnapprove = _dbContext.Posts.FirstOrDefault(p => p.Id == id);
+        if (postToUnapprove == null)
+        {
+            return NotFound();
+        }
+
+        postToUnapprove.IsApproved = false;
+        _dbContext.SaveChanges();
+        
+        return NoContent();
     }
 
     [HttpGet("{id}/subscribedPosts")]

--- a/client/src/components/posts/PostDetails.jsx
+++ b/client/src/components/posts/PostDetails.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { createSubscription, getSubscriptionsById, removeSubscription } from "../../managers/subscriptionManager.js";
 import { createPostReaction, deletePostReaction } from "../../managers/postReactionManager.js";
-import { deletePost, getApprovedAndPublishedPostById } from "../../managers/postManager.js";
+import { deletePost, getApprovedAndPublishedPostById, unapprovePost } from "../../managers/postManager.js";
 import { getAllTags } from "../../managers/tagManager.js";
 import PostTagsModal from "../modals/PostTagsModal.jsx";
 import PageContainer from "../PageContainer.jsx";
@@ -36,47 +36,46 @@ export const PostDetails = ({ loggedInUser }) => {
         })
     }
 
+    const handleCreatePostReaction = (reactionId) => {
+        const postReaction = {
+            userProfileId: loggedInUser.id,
+            postId: id,
+            reactionId: reactionId,
+        };
 
-  const handleCreatePostReaction = (reactionId) => {
-    const postReaction = {
-      userProfileId: loggedInUser.id,
-      postId: id,
-      reactionId: reactionId,
+        createPostReaction(postReaction).then(() => {
+            getApprovedAndPublishedPostById(id).then(setPost);
+        });
     };
 
-    createPostReaction(postReaction).then(() => {
-      getApprovedAndPublishedPostById(id).then(setPost);
-    });
-  };
+    const handleDeletePostReaction = (reactionId) => {
+        const postReaction = {
+            userProfileId: loggedInUser.id,
+            postId: id,
+            reactionId: reactionId,
+        };
 
-  const handleDeletePostReaction = (reactionId) => {
-    const postReaction = {
-      userProfileId: loggedInUser.id,
-      postId: id,
-      reactionId: reactionId,
+        deletePostReaction(postReaction).then(() => {
+            getApprovedAndPublishedPostById(id).then(setPost);
+        });
     };
 
-    deletePostReaction(postReaction).then(() => {
-      getApprovedAndPublishedPostById(id).then(setPost);
-    });
-  };
+    const handleSubscribe = (authorId, followerId) => {
+        const newSubscription = {
+            creatorId: authorId,
+            followerId: followerId,
+        };
 
-  const handleSubscribe = (authorId, followerId) => {
-    const newSubscription = {
-      creatorId: authorId,
-      followerId: followerId,
+        createSubscription(newSubscription).then(() => {
+            getSubscriptionsById(loggedInUser.id).then(setUserSubscriptions);
+        });
     };
 
-    createSubscription(newSubscription).then(() => {
-      getSubscriptionsById(loggedInUser.id).then(setUserSubscriptions);
-    });
-  };
-
-  const handleUnsubscribe = (CreatorId, followerId) => {
-    removeSubscription(CreatorId, followerId).then(() => {
-      getSubscriptionsById(loggedInUser.id).then(setUserSubscriptions);
-    });
-  };
+    const handleUnsubscribe = (CreatorId, followerId) => {
+        removeSubscription(CreatorId, followerId).then(() => {
+            getSubscriptionsById(loggedInUser.id).then(setUserSubscriptions);
+        });
+    };
 
     const toggleModal = () => {
         setIsModalOpen(!isModalOpen)
@@ -84,6 +83,12 @@ export const PostDetails = ({ loggedInUser }) => {
 
     const toggleDeleteModal = () => {
         setIsDeleteModalOpen(!isDeleteModalOpen)
+    }
+
+    const handleUnapprove = () => {
+        unapprovePost(id).then(() => {
+            navigate("/posts")
+        })
     }
     
     if (!post) {
@@ -185,6 +190,9 @@ export const PostDetails = ({ loggedInUser }) => {
                                     <Button onClick={toggleModal}>Manage Tags</Button>
                                     <Button onClick={() => navigate("edit")}>Edit</Button>
                                 </>
+                            )}
+                            {loggedInUser.roles.includes("Admin") && (
+                                <Button onClick={handleUnapprove}>Unapprove</Button>
                             )}
                             {(loggedInUser.id == post.userProfileId || loggedInUser.roles.includes("Admin")) && (
                                 <Button onClick={toggleDeleteModal}>Delete</Button>

--- a/client/src/managers/postManager.js
+++ b/client/src/managers/postManager.js
@@ -63,12 +63,11 @@ export const getUnapprovedPosts = () => {
 }
 
 export const approvePost = (postId) => {
-    return fetch(`${_apiUrl}/${postId}/approve`,{
-        method: "PUT",
-        headers: {
-            "Content-Type":"application.json"
-        }
-    })
+    return fetch(`${_apiUrl}/${postId}/approve`, {method: "PUT"})
+}
+
+export const unapprovePost = (postId) => {
+    return fetch(`${_apiUrl}/${postId}/unapprove`, {method: "PUT"})
 }
 
 export const getUnapprovedCount = () => {


### PR DESCRIPTION
### Purpose
To allow Admins to unapprove Posts

### Files Changed
- Added endpoint that sets a Posts' IsApproved property to false in `PostController.cs`
- Added fetch to unapprove a Post in `postManager.js`
- Added button that only renders for Admins that allow them to unapprove the Post in `PostDetails.jsx`

### To Test
Fetch, setup, and run according to project README, then confirm the following
- As an Admin, you can see an "Unapprove" button in the list of buttons in the bottom right of a Post in the Post Details view
- Clicking the "Unapprove" button unapproves the Post, and navigates the Admin back to the Posts List view
- The unapproved Post no longer shows up in the Posts List view (if published)
- The unapproved Post now shows up in the Unapproved Posts List view
- Approving the Post in the Unapproved Posts List view causes the Post to once again appear in the Posts List view (if published)

closes #6